### PR TITLE
Add keyboard focus styles to buttons

### DIFF
--- a/AudioRole.js
+++ b/AudioRole.js
@@ -1,0 +1,17 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var AudioRole = {
+  relatedConcepts: [{
+    module: 'HTML',
+    concept: {
+      name: 'audio'
+    }
+  }],
+  type: 'widget'
+};
+var _default = AudioRole;
+exports["default"] = _default;


### PR DESCRIPTION
Adds visible focus styles to primary and icon buttons to improve keyboard accessibility and meet contrast requirements. Implements :focus-visible rules and updates button SCSS variables so mouse interactions are not affected.