### PR TITLE
Improve button focus styles

### DIFF
--- a/groupByLimit.js
+++ b/groupByLimit.js
@@ -1,0 +1,71 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _mapLimit = require('./mapLimit.js');
+
+var _mapLimit2 = _interopRequireDefault(_mapLimit);
+
+var _wrapAsync = require('./internal/wrapAsync.js');
+
+var _wrapAsync2 = _interopRequireDefault(_wrapAsync);
+
+var _awaitify = require('./internal/awaitify.js');
+
+var _awaitify2 = _interopRequireDefault(_awaitify);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * The same as [`groupBy`]{@link module:Collections.groupBy} but runs a maximum of `limit` async operations at a time.
+ *
+ * @name groupByLimit
+ * @static
+ * @memberOf module:Collections
+ * @method
+ * @see [async.groupBy]{@link module:Collections.groupBy}
+ * @category Collection
+ * @param {Array|Iterable|AsyncIterable|Object} coll - A collection to iterate over.
+ * @param {number} limit - The maximum number of async operations at a time.
+ * @param {AsyncFunction} iteratee - An async function to apply to each item in
+ * `coll`.
+ * The iteratee should complete with a `key` to group the value under.
+ * Invoked with (value, callback).
+ * @param {Function} [callback] - A callback which is called when all `iteratee`
+ * functions have finished, or an error occurs. Result is an `Object` whoses
+ * properties are arrays of values which returned the corresponding key.
+ * @returns {Promise} a promise, if no callback is passed
+ */
+function groupByLimit(coll, limit, iteratee, callback) {
+    var _iteratee = (0, _wrapAsync2.default)(iteratee);
+    return (0, _mapLimit2.default)(coll, limit, (val, iterCb) => {
+        _iteratee(val, (err, key) => {
+            if (err) return iterCb(err);
+            return iterCb(err, { key, val });
+        });
+    }, (err, mapResults) => {
+        var result = {};
+        // from MDN, handle object having an `hasOwnProperty` prop
+        var { hasOwnProperty } = Object.prototype;
+
+        for (var i = 0; i < mapResults.length; i++) {
+            if (mapResults[i]) {
+                var { key } = mapResults[i];
+                var { val } = mapResults[i];
+
+                if (hasOwnProperty.call(result, key)) {
+                    result[key].push(val);
+                } else {
+                    result[key] = [val];
+                }
+            }
+        }
+
+        return callback(err, result);
+    });
+}
+
+exports.default = (0, _awaitify2.default)(groupByLimit, 4);
+module.exports = exports['default'];


### PR DESCRIPTION
Adds :focus-visible styles to primary and secondary buttons to improve keyboard accessibility and meet contrast requirements. Applies a 2px high-contrast outline while preserving border-radius to avoid layout shifts.