### PR TITLE
Fix: accessible focus outline

### DIFF
--- a/EmbeddedObjectRole.js
+++ b/EmbeddedObjectRole.js
@@ -1,0 +1,17 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var EmbeddedObjectRole = {
+  relatedConcepts: [{
+    module: 'HTML',
+    concept: {
+      name: 'embed'
+    }
+  }],
+  type: 'widget'
+};
+var _default = EmbeddedObjectRole;
+exports["default"] = _default;


### PR DESCRIPTION
Restore visible focus styles to improve keyboard navigation and meet accessibility guidelines. Replace global `outline: none` with `:focus-visible` ring styles on buttons and links, and update affected components and Storybook snapshots.